### PR TITLE
fix: update eodag version

### DIFF
--- a/src/opentelemetry/instrumentation/eodag/package.py
+++ b/src/opentelemetry/instrumentation/eodag/package.py
@@ -16,6 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-_instruments = ("eodag ~= 2.0",)
+_instruments = ("eodag > 2.0",)
 
 _supports_metrics = True


### PR DESCRIPTION
update eodag version because it will be 3.x when the open-telemetry feature is merged
