### PR TITLE
refactor: adapt wrapper for search metrics to stac-fastapi-eodag server

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,9 @@ authors = [
 license = {file = "LICENSE"}
 requires-python = ">=3.6"
 dependencies = [
-    "eodag[server]",
+    "eodag",
+    "stac-fastapi.types",
+    "stac-fastapi-eodag @ git+https://gitlab.si.c-s.fr/aubin.lambare/stac-fastapi-eodag",
     "opentelemetry-api",
     "opentelemetry-sdk",
 ]


### PR DESCRIPTION
Adapt the library to collect the search metrics from `stac-fastapi-eodag` instead of `eodag[server]`.
