### PR TITLE
fix: use alias in download metrics

### DIFF
--- a/src/opentelemetry/instrumentation/eodag/__init__.py
+++ b/src/opentelemetry/instrumentation/eodag/__init__.py
@@ -457,15 +457,19 @@ def _instrument_download(
     ) -> StreamResponse:
         span_name = "core-download"
         # Don't use there the provider's product type.
+        product_type = product.product_type
+        if "alias" in product.properties:
+            product_type = product.properties["alias"]
+
         attributes = {
             "provider": product.provider,
-            "product_type": product.product_type,
+            "product_type": product_type,
         }
         number_downloads_counter.add(
             1,
             {
                 "provider": product.provider,
-                "product_type": product.product_type,
+                "product_type": product_type,
             },
         )
 
@@ -649,7 +653,10 @@ class EODAGInstrumentor(BaseInstrumentor):
             for product_type in self._eodag_api.list_product_types(
                 provider, fetch_providers=False
             ):
-                attributes = {"provider": provider, "product_type": product_type["_id"]}
+                pt = product_type["_id"]
+                if "alias" in product_type:
+                    pt = product_type["alias"]
+                attributes = {"provider": provider, "product_type": pt}
                 downloaded_data_counter.add(0, attributes)
                 number_downloads_counter.add(0, attributes)
 


### PR DESCRIPTION
If a product type has an alias, the alias shall be used instead of the id in the number_downloads_total and downloaded_data_bytes_total metrics.

TODO: currently the request duration and request overhead duration metrics are not created for the download because we don't enter in the wrapper_download_client_get_data.
