### PR TITLE
refactor: use search from eodag library for metrics

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ license = {file = "LICENSE"}
 requires-python = ">=3.9"
 dependencies = [
     "eodag",
-    "stac-fastapi.types",
     "opentelemetry-api",
     "opentelemetry-sdk",
 ]


### PR DESCRIPTION
refactor the instrument_search so that it collects all metrics based on functions from the eodag library instead of stac_fastapi_eodag
