### PR TITLE
refactor: adapt to changed methods in eodag

### DIFF
--- a/src/opentelemetry/instrumentation/eodag/metrics.py
+++ b/src/opentelemetry/instrumentation/eodag/metrics.py
@@ -163,7 +163,7 @@ def init_and_patch(meter: Meter, eodag_api: EODataAccessGateway) -> None:
     )
 
     for provider in eodag_api.providers:
-        for collection in eodag_api.list_collections(provider, fetch_providers=False):
+        for collection in eodag_api.list_collections(providers=[provider]):
             attributes = {
                 "provider": provider,
                 "collection": collection.id,
@@ -178,7 +178,7 @@ def init_and_patch(meter: Meter, eodag_api: EODataAccessGateway) -> None:
         description="The number of searches by provider and collection",
     )
 
-    for collection in eodag_api.list_collections(fetch_providers=False):
+    for collection in eodag_api.list_collections():
         searched_collections_counter.add(0, {"collection": collection.id})
 
     _instrument_search(searched_collections_counter)

--- a/src/opentelemetry/instrumentation/eodag/metrics.py
+++ b/src/opentelemetry/instrumentation/eodag/metrics.py
@@ -76,7 +76,7 @@ def _create_stream_download_wrapper(
     downloaded_data_counter: Counter,
     number_downloads_counter: Histogram,
 ) -> Callable[..., Any]:
-    """Create a wrapper for _stream_download_dict methods with common instrumentation logic."""
+    """Create a wrapper for stream_download methods with common instrumentation logic."""
 
     safe_add_downloads = safe_metrics_call(number_downloads_counter.add)
     safe_add_data = safe_metrics_call(downloaded_data_counter.add)
@@ -126,7 +126,7 @@ def _instrument_download(downloaded_data_counter: Counter, number_downloads_coun
         if hasattr(http_module, "HTTPDownload"):
             wrap_function_wrapper(
                 http_module,
-                "HTTPDownload._stream_download_dict",
+                "HTTPDownload.stream_download",
                 _create_stream_download_wrapper(
                     downloaded_data_counter,
                     number_downloads_counter,
@@ -141,7 +141,7 @@ def _instrument_download(downloaded_data_counter: Counter, number_downloads_coun
         if hasattr(aws_module, "AwsDownload"):
             wrap_function_wrapper(
                 aws_module,
-                "AwsDownload._stream_download_dict",
+                "AwsDownload.stream_download",
                 _create_stream_download_wrapper(
                     downloaded_data_counter,
                     number_downloads_counter,
@@ -206,13 +206,13 @@ def remove_patches():
     try:
         http_module = importlib.import_module("eodag.plugins.download.http")
         if hasattr(http_module, "HTTPDownload"):
-            patches.append((http_module.HTTPDownload, "_stream_download_dict"))
+            patches.append((http_module.HTTPDownload, "stream_download"))
     except ImportError:
         pass
 
     try:
         aws_module = importlib.import_module("eodag.plugins.download.aws")
         if hasattr(aws_module, "AwsDownload"):
-            patches.append((aws_module.AwsDownload, "_stream_download_dict"))
+            patches.append((aws_module.AwsDownload, "stream_download"))
     except ImportError:
         pass

--- a/src/opentelemetry/instrumentation/eodag/tracing.py
+++ b/src/opentelemetry/instrumentation/eodag/tracing.py
@@ -28,9 +28,7 @@ def traced_method(tracer: Tracer, span_name: str):
     def decorator(func):
         @functools.wraps(func)
         def wrapper(*args, **kwargs):
-            with tracer.start_as_current_span(
-                span_name, kind=SpanKind.INTERNAL
-            ) as span:
+            with tracer.start_as_current_span(span_name, kind=SpanKind.INTERNAL) as span:
                 # Ajoute tous les kwargs comme attributs
                 for k, v in kwargs.items():
                     if isinstance(v, (str, int, float, bool)):
@@ -55,27 +53,25 @@ def traced_method(tracer: Tracer, span_name: str):
 def patch_eodag(tracer: Tracer):
     """Patch EODAGPluginMount and EODataAccessGateway public methods for tracing."""
     from eodag.api.core import EODataAccessGateway
-    from eodag.plugins.manager import PluginManager
+    from eodag.plugins.base import EODAGPluginMount
 
     # Patch EODAGPluginMount to trace plugin public methods
-    orig_build_plugin = PluginManager._build_plugin
+    orig_get_plugin_by_class_name = EODAGPluginMount.get_plugin_by_class_name
 
-    def new_build_plugin(*args, **kwargs):
+    def new_get_plugin_by_class_name(*args, **kwargs):
         """Wrap all public methods of a plugin instance with tracing."""
-        plugin = orig_build_plugin(*args, **kwargs)
+        plugin = orig_get_plugin_by_class_name(*args, **kwargs)
         for attr_name in dir(plugin):
             if attr_name.startswith("_"):
                 continue
             attr = getattr(plugin, attr_name)
             if callable(attr) and not getattr(attr, "_otel_tracing_applied", False):
-                wrapped = traced_method(
-                    tracer, f"{plugin.__class__.__name__}.{attr_name}"
-                )(attr)
+                wrapped = traced_method(tracer, f"{plugin.__class__.__name__}.{attr_name}")(attr)
                 setattr(plugin, attr_name, wrapped)
 
         return plugin
 
-    PluginManager._build_plugin = new_build_plugin
+    EODAGPluginMount.get_plugin_by_class_name = new_get_plugin_by_class_name
 
     # Patch EODataAccessGateway to trace core public methods
     for attr_name in dir(EODataAccessGateway):


### PR DESCRIPTION
- `fetch_providers` property in `list_collections` does not exist anymore, `provider` has changed to `providers`
- `PluginManager._build_plugin` has been changed to `EODAGPluginMount.get_plugin_by_class_name`
