### PR TITLE
fix(metrics): allow init_and_patch with eodag_api=None

### DIFF
--- a/src/opentelemetry/instrumentation/eodag/metrics.py
+++ b/src/opentelemetry/instrumentation/eodag/metrics.py
@@ -162,14 +162,15 @@ def init_and_patch(meter: Meter, eodag_api: EODataAccessGateway) -> None:
         description="Number of downloads from each provider and collection",
     )
 
-    for provider in eodag_api.providers:
-        for collection in eodag_api.list_collections(provider, fetch_providers=False):
-            attributes = {
-                "provider": provider,
-                "collection": collection.id,
-            }
-            downloaded_data_counter.add(0, attributes)
-            number_downloads_counter.add(0, attributes)
+    if eodag_api is not None:
+        for provider in eodag_api.providers:
+            for collection in eodag_api.list_collections(provider, fetch_providers=False):
+                attributes = {
+                    "provider": provider,
+                    "collection": collection.id,
+                }
+                downloaded_data_counter.add(0, attributes)
+                number_downloads_counter.add(0, attributes)
 
     _instrument_download(downloaded_data_counter, number_downloads_counter)
 
@@ -178,8 +179,9 @@ def init_and_patch(meter: Meter, eodag_api: EODataAccessGateway) -> None:
         description="The number of searches by provider and collection",
     )
 
-    for collection in eodag_api.list_collections(fetch_providers=False):
-        searched_collections_counter.add(0, {"collection": collection.id})
+    if eodag_api is not None:
+        for collection in eodag_api.list_collections(fetch_providers=False):
+            searched_collections_counter.add(0, {"collection": collection.id})
 
     _instrument_search(searched_collections_counter)
 

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -17,6 +17,16 @@
 # limitations under the License.
 """Opentelemetry tests."""
 
+from unittest.mock import MagicMock, patch
+
+from opentelemetry.instrumentation.eodag import metrics
+
 
 def test_needed():
     pass
+
+
+def test_init_and_patch_accepts_none_eodag_api():
+    meter = MagicMock()
+    with patch.object(metrics, "_instrument_download"), patch.object(metrics, "_instrument_search"):
+        metrics.init_and_patch(meter, None)


### PR DESCRIPTION
### Your checklist for this pull request
Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.

### Description

Fixes #23. `EODAGInstrumentor` accepts `eodag_api=None` (per the constructor docstring), but `metrics.init_and_patch` then dereferences `eodag_api.providers` and `eodag_api.list_collections(...)` unconditionally, so `instrument()` raises `AttributeError: 'NoneType' object has no attribute 'providers'` whenever no API instance is passed in (e.g. unit tests that don't configure a provider).

Guard the two provider/collection loops with `if eodag_api is not None`. Counter creation and the download/search wrappers still run, so HTTP/AWS download instrumentation is unaffected.

### Further comments

The bug report mentions `available_providers()`; the equivalent in the current code (after the eodag v4 collection refactor in #22) is `eodag_api.providers`, and reproduces the same way.

`tests/test_telemetry.py::test_init_and_patch_accepts_none_eodag_api` is a true regression test: it fails on `main` with `AttributeError: 'NoneType' object has no attribute 'providers'` and passes after this commit. `_instrument_download` and `_instrument_search` are patched in the test so it covers the loop guards without depending on which version of eodag is installed.

Note for default branch: this PR targets `main` because `develop` does not exist on this repo (`gh repo view CS-SI/opentelemetry-instrumentation-eodag` reports `defaultBranchRef.name = "main"`); happy to retarget if a different base is preferred.